### PR TITLE
Modified SiliTune.desktop and Tested your Program

### DIFF
--- a/SiliTune.desktop
+++ b/SiliTune.desktop
@@ -1,6 +1,8 @@
 [Desktop Entry]
 Type=Application
 Name=SiliTune
-Exec=sudo nohup python /home/petergu/MyHome/Working/SiliTune/silitune.py &
+Categories=System;
+Exec=xdg-su -c 'nohup python3 /home/petergu/MyHome/Working/SiliTune/silitune.py'
+Icon=/home/petergu/MyHome/Working/SiliTune/icon.png
 Path=/home/petergu/MyHome/Working/SiliTune/
-Terminal=true
+Terminal=false


### PR DESCRIPTION
I have just tried your project on my computer (MacBook Air mid-2013 with openSUSE Leap 15.1) and I have found a few problems, both before and after starting up your program.

### Launching the Program

I have countered some problem when running the command in your `.desktop` file.

When I ran `sudo nohup python3 ./silitune.py`, I got the following result:

```bash
QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/tmp/runtime-root'
qt.qpa.screen: QXcbConnection: Could not connect to display 
Could not connect to any X display.
```

and the program failed to start. So I tried `xdg-su -c ‘python3 ./silitune.py’` and it works. So I changed `sudo` to `xdg-su` in the `.desktop` file.

### Tray Icon

Tray icon is **not working** in KDE currently. I will open an issue for that.

### Intel Undervolting

I have not tested that yet.

### TLP functions

Works. Checked with `sudo tlp-stat`.

### CPU Core Tuning

Works. Checked with `nproc`.

### Turbo Boost Tuning

Works. Checked with `sudo tlp-stat`

### On-Boot Profile

After launching this program, the profile is set to `Battery`, although the system might be attached to an AC cable. I suggest detecting whether the power source is AC before loading settings. I will open an issue for this.